### PR TITLE
Fix main to use v1/config instead of golang-user-microservice/config

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "debug" : true,
   "server" : {
     "port" : "80",
+    "waitdurationforgracefulshutdown": "15s",
     "secret" : "whU6kroaCL1sou1UM5iOuPa1XZnmZ3g6"
   },
   "database" : {

--- a/config/app.go
+++ b/config/app.go
@@ -15,7 +15,8 @@ type Configurations struct {
 }
 
 type ServerConfig struct {
-	Port string
+	Port                            string
+	WaitDurationForGracefulShutdown string
 }
 
 type DatabaseConfig struct {

--- a/main.go
+++ b/main.go
@@ -1,20 +1,30 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"time"
+	"v1/config"
 	"v1/core"
-	"v1/env"
-	"golang-user-microservice/config"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 )
 
 func main() {
-
 	config.ReadConfig()
+
+	// Parsing wait for graceful shutdown setting
+	wait, err := time.ParseDuration(config.App.Server.WaitDurationForGracefulShutdown)
+
+	if err != nil {
+		log.Printf("Failed to parse wait duration of '%s' shutdown without waiting for connections to close.", config.App.Server.WaitDurationForGracefulShutdown)
+		wait = 0
+	}
 
 	cor := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
@@ -32,7 +42,40 @@ func main() {
 	router.HandleFunc("/api/users/{uuid}", core.OnUpdateUser).Methods("PUT")
 
 	handler := cor.Handler(router)
-	http.ListenAndServe(config.App.Server.Port, handler)
-	log.Printf("Port:%s Listening!", config.App.Server.Port)
+	address := fmt.Sprintf(":%s", config.App.Server.Port)
 
+	server := &http.Server{
+		Addr:    address,
+		Handler: handler,
+	}
+
+	// Run our server in a goroutine so that it doesn't block.
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	log.Printf("Started server listening at %s", address)
+
+	c := make(chan os.Signal, 1)
+	// We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C)
+	// SIGKILL, SIGQUIT or SIGTERM (Ctrl+/) will not be caught.
+	signal.Notify(c, os.Interrupt)
+
+	// Block until we receive our signal.
+	<-c
+	log.Printf("Waiting %s for connections to close.", wait.String())
+
+	// Create a deadline to wait for
+	ctx, cancel := context.WithTimeout(context.Background(), wait)
+	defer cancel()
+	// Doesn't block if no connections, but will otherwise wait
+	// until the timeout deadline.
+	server.Shutdown(ctx)
+	// Optionally, you could run srv.Shutdown in a goroutine and block on
+	// <-ctx.Done() if your application should wait for other services
+	// to finalize based on context cancellation.
+	log.Println("Server gracefully shutdown.")
+	os.Exit(0)
 }


### PR DESCRIPTION
The project failed to build because golang-user-microservice/config was used instead of v1/config.
This PR fixes that and adds graceful shutdown for the server.

For more information about modules https://blog.golang.org/using-go-modules