### PR TITLE
feat: simple unit test around default database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDEs and Editors
+.idea

--- a/data/database_test.go
+++ b/data/database_test.go
@@ -1,0 +1,19 @@
+package data
+
+import (
+	"fmt"
+	"testing"
+	"reflect"
+)
+
+/**
+Test to ensure that a default database is generated
+*/
+func TestNewDatabase(t *testing.T) {
+	db := newDatabase()
+
+	fmt.Print("type of db: ", reflect.TypeOf(db))
+	if reflect.TypeOf(db).String() != "*gorm.DB" {
+		t.Errorf("newDatabase didn't return a default database, instead got %s", reflect.TypeOf(db).String())
+	}
+}


### PR DESCRIPTION
closes #16 

Added simple test to ensure that, in the testing state where no `env` would be, that a database instance was returned.

Simple stuff, but I've only done unit testing in golang once or twice in the last couple of years so it was all a good refresher! 

:bow: 